### PR TITLE
Switch to foundation slack invite

### DIFF
--- a/index.md
+++ b/index.md
@@ -32,7 +32,7 @@ Check out the OWASP SAMM v2 model [online](https://owaspsamm.org/model/):<br>
 **Join us on the OWASP SAMM project Slack channel**
 
   - [Join our project slack channel](https://owasp.slack.com/messages/C0VF1EJGH)
-  - Invitations (self registration) via: https://owasp-slack.herokuapp.com/
+  - Invitations (self registration) via: <https://owas.org/slack/invite>
     
 **Join our monthly calls**
 

--- a/index.md
+++ b/index.md
@@ -32,7 +32,7 @@ Check out the OWASP SAMM v2 model [online](https://owaspsamm.org/model/):<br>
 **Join us on the OWASP SAMM project Slack channel**
 
   - [Join our project slack channel](https://owasp.slack.com/messages/C0VF1EJGH)
-  - Invitations (self registration) via: <https://owas.org/slack/invite>
+  - Invitations (self registration) via: <https://owasp.org/slack/invite>
     
 **Join our monthly calls**
 


### PR DESCRIPTION
To avoid the problems around the herokuapp going down toward the end of the month due to usage limits a new mechanism has been setup. It's also simple for the foundation to make a redirect for /slack/invite for future changes as well.